### PR TITLE
Update msc-profile-view.js

### DIFF
--- a/elements/msc-profile-view/msc-profile-view.js
+++ b/elements/msc-profile-view/msc-profile-view.js
@@ -1020,7 +1020,7 @@ Polymer({
 
     var menu = new nw.Menu({ type: 'menubar' });
     if (platform.includes("darwin")) {
-      menu.createMacBuiltin('Musicoin-wallet',{hideEdit: true, hideWindow: true});
+      menu.createMacBuiltin('Musicoin',{hideEdit: false, hideWindow: true});
       } else {}
     var account = new nw.Menu();
 


### PR DESCRIPTION
unhide the edit menu and pretty up the name on the menu - this is a workaround for command+c and command+v on mac os.