### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "bower-installer -p",
     "install": "bower-installer -p",
     "test": "yarn build"
-  }
+  },
   "dependencies": {
     "bower-installer": "1.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "install": "yarn bower-installer -p",
-    "test": "echo 'No tests yet.'"
-  },
+    "build": "bower-installer -p",
+    "install": "bower-installer -p",
+    "test": "yarn build"
+  }
   "dependencies": {
     "bower-installer": "1.3.6"
   }


### PR DESCRIPTION
handle bower deps in a build step for rebuilding bower deps upon yarn add/install as dep itself.

-- this removes the need to rely on bower at all in the main app

cleanly works with  https://github.com/Musicoin/desktop/pull/252